### PR TITLE
Add error explanation screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Flutter build outputs
+build/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+pubspec.lock
+
+# Python test cache
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # irevive
+
+## Overview
+irevive is a cross-platform smartphone diagnostics tool designed to perform deep analysis on both Android and iOS devices. The goal is to help users identify issues, collect logs, and understand frequent problems through clear explanations. By offering a unified application, troubleshooting is consistent no matter which mobile platform is used.
+
+## Chosen Technology
+The project uses **Flutter** with the **Dart** language. Flutter compiles to native code on Android and iOS, delivering high performance with a single codebase and modern UI components. React Native with TypeScript was considered, but Flutter was chosen for its straightforward setup and predictable look across platforms.
+
+## Key Features
+- **Comprehensive log collection** to aid in debugging and support cases.
+- **Error explanations** that describe known issues in plain language.
+- **Frequent issue tracking** with recommendations for fixes.
+- **Hardware tests** such as battery health checks and sensor diagnostics.
+- **Device info screen** showing device details and battery level.
+- **Error explanation screen** listing common issues and their fixes.
+
+## Prerequisites
+Install the following tools before building the application:
+- Android SDK (platform tools and emulator images)
+- Flutter SDK and CLI (run `flutter doctor` after installation)
+- Any backend dependencies required for log storage or analytics
+
+If you plan to build the iOS version, you will also need Xcode on a macOS
+machine. For Windows development you can skip Xcode entirely.
+
+
+## Project Structure
+The `app/` directory contains the Flutter project used to build the mobile application. Source code lives in `app/lib/` and dependencies are listed in `app/pubspec.yaml`.
+
+## Getting Started
+Run the following commands after installing the prerequisites. On Windows you
+can run the desktop version of the app directly:
+
+```bash
+cd app
+flutter pub get
+flutter run -d windows
+```
+
+These commands fetch packages and launch the application on a connected device or emulator.
+
+## iOS Diagnostics on Windows
+To run diagnostics directly on an iPhone, the app must be built for iOS and
+installed on the device. Building iOS binaries requires Xcode on macOS. If you
+only have a Windows PC, you can still use the Windows desktop build, but it will
+not communicate with an attached iPhone. A macOS environment is necessary to
+compile and deploy the iOS version.
+

--- a/app/lib/device_info_screen.dart
+++ b/app/lib/device_info_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:battery_plus/battery_plus.dart';
+
+class DeviceInfoScreen extends StatefulWidget {
+  const DeviceInfoScreen({super.key});
+
+  @override
+  State<DeviceInfoScreen> createState() => _DeviceInfoScreenState();
+}
+
+class _DeviceInfoScreenState extends State<DeviceInfoScreen> {
+  final DeviceInfoPlugin _deviceInfo = DeviceInfoPlugin();
+  final Battery _battery = Battery();
+  String _deviceData = 'Loading...';
+  String _batteryLevel = 'Loading...';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadInfo();
+  }
+
+  Future<void> _loadInfo() async {
+    try {
+      final info = await _deviceInfo.deviceInfo;
+      final battery = await _battery.batteryLevel;
+      setState(() {
+        _deviceData = info.data.toString();
+        _batteryLevel = '$battery%';
+      });
+    } catch (e) {
+      setState(() {
+        _deviceData = 'Failed to load device info: $e';
+        _batteryLevel = 'Unknown';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Device Info')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Battery: $_batteryLevel'),
+            const SizedBox(height: 12),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Text(_deviceData),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/error_explanation_screen.dart
+++ b/app/lib/error_explanation_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class ErrorExplanationScreen extends StatelessWidget {
+  const ErrorExplanationScreen({super.key});
+
+  Map<String, String> get _errors => const {
+        'battery_overheat': 'Устройство перегревается из-за чрезмерной нагрузки или поврежденной батареи.',
+        'slow_performance': 'Часто связано с нехваткой памяти или большим количеством запущенных приложений.',
+        'wifi_drops': 'Перепроверьте настройки роутера и обновите ПО устройства.',
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Частые ошибки')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: _errors.entries
+            .map(
+              (e) => ListTile(
+                title: Text(e.key),
+                subtitle: Text(e.value),
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'device_info_screen.dart';
+import 'error_explanation_screen.dart';
+
+void main() {
+  runApp(const IReviveApp());
+}
+
+class IReviveApp extends StatelessWidget {
+  const IReviveApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'iRevive Diagnostics',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomeScreen(),
+    );
+  }
+}
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Diagnostics Home')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Welcome to iRevive!'),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const DeviceInfoScreen(),
+                  ),
+                );
+              },
+              child: const Text('Show Device Info'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const ErrorExplanationScreen(),
+                  ),
+                );
+              },
+              child: const Text('Common Error Explanations'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,0 +1,22 @@
+name: irevive
+description: Cross-platform smartphone diagnostics app.
+publish_to: 'none'
+
+version: 0.1.0
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  device_info_plus: ^8.0.0
+  battery_plus: ^2.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add screen that lists common errors and their explanations
- link new screen from Home in `main.dart`
- document the error explanation feature in README

## Testing
- `pytest -q`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b7136ad888322aa0c1047efcc5092